### PR TITLE
Save UserID for client

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -355,6 +355,7 @@ func (ctrl *OAuthController) CreateClientHandler(w http.ResponseWriter, r *http.
 		ID:     id,
 		Secret: secret,
 		Domain: req.Domain,
+		UserID: req.UserID,
 	})
 	if err != nil {
 		logrus.Errorf("Error storing client info %s", err.Error())


### PR DESCRIPTION
this allows us to reference the owner of that oauth client app And I think in grant_type client_credentials this user ID is used for the lndhub request