### PR TITLE
feat: add access token expiry handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to access the Alby Wallet API in their name. Possible use-cases include:
 All examples are using [httpie](https://httpie.io)
 - Make a POST request to the oauth server in order to get an access code. This should be made from the browser, as the responds redirects the client back to the client application.
 	```
-	http -f POST https://api.regtest.getalby.com/oauth/authorize\?client_id=test_client\&response_type=code\&redirect_uri=localhost:8080/client_app\&scope\=balance:read login=$login password=$password
+	http -f POST https://api.regtest.getalby.com/oauth/authorize\?client_id=test_client\&response_type=code\&redirect_uri=localhost:8080/client_app\&scope\=balance:read login=$login password=$password expires_in=<optional, token expiry in seconds>
 	```
 	- `redirect_uri` should be a web or native uri where the client should be redirected once the authorization is complete.
 	- You will need a `client_id` and a `client_secret`. For regtest, you can use `test_client` and `test_secret`.
@@ -25,6 +25,7 @@ All examples are using [httpie](https://httpie.io)
 	- `$login` and `$password` should be your LNDHub login and password.
   The response should be a `302 Found` with the `Location` header equal to the redirect URL with the code in it:
 	`Location: localhost:8080/client_app?code=YOUR_CODE`
+  - The `expires_in` parameter (optional) allows you to specify the expiry duration of the token in seconds.
 - Fetch an access token and a refresh token using the authorization code obtained in the previous step `oauth/token` by doing a HTTP POST request with form parameters:
 	```
 	http -a test_client:test_secret 

--- a/integration_tests/create_token_test.go
+++ b/integration_tests/create_token_test.go
@@ -82,7 +82,7 @@ func fetchCode(id, redirect, scope string, controller *controllers.OAuthControll
 	values.Add("scope", scope)
 	values.Add("login", testAccountLogin)
 	values.Add("password", testAccountPassword)
-	values.Add("expires_at", "3600")
+	values.Add("expires_in", "3600")
 	req, err := http.NewRequest("POST", "/oauth/authorize", strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, err

--- a/integration_tests/create_token_test.go
+++ b/integration_tests/create_token_test.go
@@ -82,6 +82,7 @@ func fetchCode(id, redirect, scope string, controller *controllers.OAuthControll
 	values.Add("scope", scope)
 	values.Add("login", testAccountLogin)
 	values.Add("password", testAccountPassword)
+	values.Add("expires_at", "3600")
 	req, err := http.NewRequest("POST", "/oauth/authorize", strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, err

--- a/service/service.go
+++ b/service/service.go
@@ -40,6 +40,14 @@ func CombinedClientInfoHandler(r *http.Request) (clientID, clientSecret string, 
 	return
 }
 
+func AccessTokenExpHandler(w http.ResponseWriter, r *http.Request) (exp time.Duration, err error) {
+	expiry, err := strconv.Atoi(r.FormValue("expiry"));
+	if err != nil {
+		return time.Duration(0), err
+	}
+	return time.Duration(expiry) * time.Second, nil
+}
+
 func InitService(conf *Config) (svc *Service, err error) {
 	manager := manage.NewDefaultManager()
 	manager.SetAuthorizeCodeTokenCfg(manage.DefaultAuthorizeCodeTokenCfg)
@@ -71,6 +79,7 @@ func InitService(conf *Config) (svc *Service, err error) {
 
 	srv := server.NewServer(server.NewConfig(), manager)
 	srv.ClientInfoHandler = CombinedClientInfoHandler
+	srv.AccessTokenExpHandler = AccessTokenExpHandler
 	svc = &Service{
 		DB:          db,
 		OauthServer: srv,

--- a/service/service.go
+++ b/service/service.go
@@ -83,13 +83,13 @@ func InitService(conf *Config) (svc *Service, err error) {
 
 	srv := server.NewServer(server.NewConfig(), manager)
 	srv.ClientInfoHandler = CombinedClientInfoHandler
-	srv.AccessTokenExpHandler = svc.AccessTokenExpHandler
 	svc = &Service{
 		DB:          db,
 		OauthServer: srv,
 		Config:      conf,
 		ClientStore: clientStore,
 	}
+	srv.AccessTokenExpHandler = svc.AccessTokenExpHandler
 	return svc, nil
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -41,11 +41,17 @@ func CombinedClientInfoHandler(r *http.Request) (clientID, clientSecret string, 
 }
 
 func AccessTokenExpHandler(w http.ResponseWriter, r *http.Request) (exp time.Duration, err error) {
-	expiry, err := strconv.Atoi(r.FormValue("expiry"));
-	if err != nil {
-		return time.Duration(0), err
+	var expiresAt int
+	expiry := r.FormValue("expires_at");
+	if expiry != "" {
+		expiresAt, err = strconv.Atoi(expiry);
+		if err != nil {
+			return time.Duration(0), err
+		}
+	} else {
+		expiresAt = 7200
 	}
-	return time.Duration(expiry) * time.Second, nil
+	return time.Duration(expiresAt) * time.Second, nil
 }
 
 func InitService(conf *Config) (svc *Service, err error) {


### PR DESCRIPTION
Fixes #67
From now on we can send ~`expiry`~ `expires_in` as form value while authorizing

<img width="100%" alt="Screenshot 2023-08-14 at 6 38 51 PM" src="https://github.com/getAlby/oauth2server/assets/64399555/6964eaa9-f822-4e27-8664-5beb936fdf55">
