### PR TITLE
chore: add form data to json logging

### DIFF
--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -101,8 +101,11 @@ func (svc *service) TokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	ti, err := svc.OauthServer.GetAccessToken(ctx, gt, tgr)
 	if err != nil {
+		r.ParseForm()
+		jsonData, _ := json.Marshal(r.Form)
 		dump, _ := httputil.DumpRequest(r, true)
 		logrus.WithField("token_request", string(dump)).
+			WithField("form_data", string(jsonData)).
 			WithField("gt", gt).WithError(err).
 			Error("error getting access token")
 		svc.tokenError(w, err)

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -105,7 +105,6 @@ func (svc *service) TokenHandler(w http.ResponseWriter, r *http.Request) {
 		logrus.WithField("token_request", string(dump)).
 			WithField("gt", gt).WithError(err).
 			Error("error getting access token")
-		sentry.CaptureException(err)
 		svc.tokenError(w, err)
 		return
 	}


### PR DESCRIPTION
### Description

Adds form data to json logging and removes sentry logging

## Example
### Request

Do this request twice (with the same old refresh token) even after getting the new access token on the first request:
```
http -a 2Vbq3uCy22:8e7P31ZFzTrqv1yrlUP4 -f POST http://localhost:8081/oauth/token\?client_id=dC3Xwf1FUR\&grant_type=refresh_token\&refresh_token=NWE5ZTC0N2ETN2VLZC01NGNHLWI4MDMTM2ZKZDZKOWZIZJUZ
```

### Response (2nd time)

```
HTTP/1.1 401 Unauthorized
Cache-Control: no-store
Content-Length: 285
Content-Type: application/json;charset=UTF-8
Date: Wed, 15 Nov 2023 06:02:23 GMT
Pragma: no-cache

{
    "error": "invalid_grant",
    "error_description": "The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client"
}
```

### Logs
```
{
    "error":"invalid_grant",
    "form_data":"{\"client_id\":[\"dC3Xwf1FUR\"],\"grant_type\":[\"refresh_token\"],\"refresh_token\":[\"NWE5ZTC0N2ETN2VLZC01NGNHLWI4MDMTM2ZKZDZKOWZIZJUZ\"]}",
    "gt":"refresh_token",
    "level":"error",
    "msg":"error getting access token",
    "time":"2023-11-15T11:27:55+05:30",
    "token_request":"POST /oauth/token HTTP/1.1\r\nHost: localhost:8081\r\nAccept: */*\r\nAccept-Encoding: gzip, deflate, br\r\nAuthorization: Bearer MZQWNZBMZTUTMTHLNY0ZYZCXLTK0NDATMZA0NGNKMDC4ZDE0\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\nContent-Length: 456\r\nContent-Type: multipart/form-data; boundary=--------------------------821657784825129212348783\r\nPostman-Token: 7cc1c2c0-6e0b-4648-acb7-1658e6e1fcd6\r\nUser-Agent: PostmanRuntime/7.35.0\r\n\r\n"
}

{
    "error":"invalid_grant",
    "error_description":"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client","level":"error","msg":"token error","time":"2023-11-15T11:27:55+05:30"
}
```