### PR TITLE
ci: bump setup-go and checkout actions

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -26,12 +26,12 @@ jobs:
       #       --health-timeout 5s
       #       --health-retries 5
       steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
           - name: Install Go
-            uses: actions/setup-go@v1
+            uses: actions/setup-go@v5
             with:
               go-version: ${{ matrix.go-version }}
-          - name: Checkout code
-            uses: actions/checkout@v2
           - name: Run tests
             run:  go test -p 1 -v -cover -coverpkg=./... ./...
           #   env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,7 +10,7 @@ jobs:
       IMAGENAME: ${{ github.event.repository.name }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       name: Check out code
     - name: Docker build
       uses: mr-smithers-excellent/docker-build-push@v5
@@ -21,7 +21,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout deployment repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: getalby/alby-deployment
         path: infrastructure


### PR DESCRIPTION
## Problem

Every PR's **Integration tests** check has been failing — not on test code, but at the **Install Go** step. `actions/setup-go@v1` (a 2019-era action) hangs while resolving/installing Go `1.20.x` on the current `ubuntu-24.04` runner: it produces no output for ~3 minutes and the job is reaped before `Run tests` ever executes. Both old actions also run on now-deprecated Node 16/20 runtimes (GitHub force-migrates to Node 24 on 2026-06-16).

Evidence from a recent run — the step starts, then 3 minutes of silence, then cleanup:
```
09:11:57  Run actions/setup-go@v1  (go-version: 1.20.x)
09:14:57  Cleaning up orphan processes
09:14:57  ##[warning] Node.js 20 actions are deprecated ... actions/setup-go@v1
```

## Change

- `actions/setup-go@v1` → `@v5` (runs on Node 24; installs Go reliably).
- Reorder `checkout` **before** `setup-go` in the test workflow, so `setup-go@v5`'s default `go.sum`-based module caching can find `go.sum`.
- `actions/checkout@v2` → `@v4` in both `integration_tests.yaml` and `workflow.yaml` (checkout@v2 runs on the even-older Node 16).

No workflow logic or test changes — purely action version bumps to unblock CI repo-wide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration and deployment workflows to use newer versions of build tools and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->